### PR TITLE
Update Swift MT regex

### DIFF
--- a/translator/integrations/ftp-sftp/swiftMtMxTranslator/constants.bal
+++ b/translator/integrations/ftp-sftp/swiftMtMxTranslator/constants.bal
@@ -86,7 +86,7 @@ const string MESSAGE_TYPE = "messageType";
 const string VALIDATION_FLAG = "ValidationFlag";
 const string VALUE = "value";
 
-regexp:RegExp mtRegex = re `^\{1:[^\}]+\}(\{2:[^\}]+\})?(\{3:[^\}]+\}\})?(\{4:\n)?(.*\n)*-\}(\{5:[^\}]+\}\})?(\{S:.*\})*`;
+regexp:RegExp mtRegex = re `^\{1:[^\}]+\}(\{2:[^\}]+\})?(\{3:(\{.*?\})\}(.*))?(\{4:\n)?(.*\n)*-\}(\{5:[^\}]+\}\})?(\{S:.*\})*`;
 
 enum status {
     SUCCESS = "success",


### PR DESCRIPTION
## Purpose
> Updated swift mt regex to handle block 3 multi blocks
`ex: {3:{108:xxxx}{121:xxxx}}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced MT message parsing to support more flexible message formats, including improved handling of nested elements and additional content variations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->